### PR TITLE
Add userId to event in default test

### DIFF
--- a/generators/app/templates/test/skill.spec.js
+++ b/generators/app/templates/test/skill.spec.js
@@ -10,6 +10,9 @@ describe('Skill', () => {
         application: {
           applicationId: '',
         },
+        user: {
+          userId: '',
+        },
       },
       request: {
         type: 'LaunchRequest',


### PR DESCRIPTION
If you configure a Voxa plugin that uses userId (e.g. voxa-ga) and run the test, it will fail with no description of why it failed. Setting up this simple property can save some debugging time for the developer.